### PR TITLE
Compatibility issue with `delimit` function in Hugo 0.120.0

### DIFF
--- a/themes/PaperMod/layouts/partials/author.html
+++ b/themes/PaperMod/layouts/partials/author.html
@@ -2,7 +2,7 @@
 {{- $author := (.Params.author | default site.Params.author) }}
 {{- $author_type := (printf "%T" $author) }}
 {{- if (or (eq $author_type "[]string") (eq $author_type "[]interface {}")) }}
-{{- (delimit $author ", " ) }}
+{{- (delimit $author ", " | safeHTML ) }}
 {{- else }}
 {{- $author }}
 {{- end }}

--- a/themes/PaperMod/layouts/partials/post_meta.html
+++ b/themes/PaperMod/layouts/partials/post_meta.html
@@ -17,5 +17,5 @@
 {{- end }}
 
 {{- with ($scratch.Get "meta") }}
-{{- delimit . "&nbsp;·&nbsp;" -}}
+{{- delimit . "&nbsp;·&nbsp;" | safeHTML -}}
 {{- end -}}


### PR DESCRIPTION
See issue https://github.com/adityatelange/hugo-PaperMod/issues/1325. Starting from Hugo 120.0.0, a compatibility issue with delimit function forces HTML character references to be displayed as plain text.

Adding the function `safeHTML` fixes the issue, as it was commited to the original PaperMod repo. Please consider adding this fix.